### PR TITLE
Migrate Profiler from Old CARTA

### DIFF
--- a/imports/animator/actions.js
+++ b/imports/animator/actions.js
@@ -7,6 +7,7 @@ import { mongoUpsert } from '../api/MongoHelper';
 import imageViewer from '../imageViewer/actions';
 import colormap from '../colormap/actions';
 import gridControl from '../gridControl/actions';
+import profiler from '../profiler/actions';
 // redux part
 const ANIMATOR_CHANGE = 'ANIMATOR_CHANGE';
 export const ActionType = {
@@ -245,6 +246,11 @@ function changeNonImageFrame(animatorType, newFrameIndex) {
           animatorType.selection.frame = newFrameIndex;
           // mongoUpsert(AnimatorDB, { animatorID: resp.data }, `Resp_${cmd}`);
           mongoUpsert(AnimatorDB, { animatorTypeList }, 'GET_ANIMATOR_DATA');
+        }
+      })
+      .then(() => {
+        if (animatorType.type === 'Stokes') {
+          dispatch(profiler.autoGenerate());
         }
       })
       .catch((e) => {

--- a/imports/animator/actions.js
+++ b/imports/animator/actions.js
@@ -282,6 +282,7 @@ function changeImageFrame(animatorTypeID, newFrameIndex) {
       })
       .then(() => {
         dispatch(gridControl.getDataGrid());
+        dispatch(profiler.autoGenerate());
       });
   };
 }

--- a/imports/api/Commands.js
+++ b/imports/api/Commands.js
@@ -7,7 +7,7 @@ const SELECT_FILE_TO_OPEN = '/CartaObjects/ViewManager:dataLoaded';
 // non-global, need object id
 
 // non-global
-//need object id
+// need object id
 const GET_ANIMATORTYPE_ID = 'registerAnimator';
 const SET_ZOOM_LEVEL = 'setZoomLevel';
 const CLOSE_IMAGE = 'closeImage';
@@ -34,6 +34,20 @@ const SET_TICK_LENGTH = 'setTickLength';
 const SET_TICK_TRANSPARENCY = 'setTickTransparency';
 const SET_TICK_THICKNESS = 'setTickThickness';
 const SET_GRID_LABEL_FORMAT = 'setGridLabelFormat';
+const GET_PROFILER_SETTINGS = 'getProfilerSettings'; // commands for profiler
+const GET_PROFILE_DATA = 'getProfileData';
+const GET_FIT_DATA = 'getFitData';
+const GET_FIT_STATISTICS = 'getFitStatistics';
+const NEW_PROFILE = 'newProfile';
+const CLEAR_PROFILES = 'clearProfiles';
+const REMOVE_PROFILE = 'removeProfile';
+const SET_AUTO_GENERATE = 'setAutoGenerate';
+const SET_AXIS_UNITS_LEFT = 'setAxisUnitsLeft';
+const SET_AXIS_UNITS_BOTTOM = 'setAxisUnitsBottom';
+const SET_FIT_CURVES = 'setFitCurves';
+const SET_GAUSS_COUNT = 'setGaussCount';
+const SET_GENERATION_MODE = 'setGenerationMode';
+const SET_SELECTED_CURVE = 'setSelectedCurve';
 
 // New commands for new CARTA:
 // const GET_DEFAULT_HISTOGRAM_ID = '/CartaObjects/ViewManager:getDefaultHistogramID';
@@ -103,6 +117,20 @@ const Commands = {
   SET_TICK_TRANSPARENCY,
   SET_TICK_THICKNESS,
   SET_GRID_LABEL_FORMAT,
+  GET_PROFILER_SETTINGS, // commands for profiler
+  GET_PROFILE_DATA,
+  GET_FIT_DATA,
+  GET_FIT_STATISTICS,
+  NEW_PROFILE,
+  CLEAR_PROFILES,
+  REMOVE_PROFILE,
+  SET_AUTO_GENERATE,
+  SET_AXIS_UNITS_LEFT,
+  SET_AXIS_UNITS_BOTTOM,
+  SET_FIT_CURVES,
+  SET_GAUSS_COUNT,
+  SET_GENERATION_MODE,
+  SET_SELECTED_CURVE,
   // GET_DEFAULT_HISTOGRAM_ID,
 };
 

--- a/imports/fileBrowser/actions.js
+++ b/imports/fileBrowser/actions.js
@@ -134,11 +134,12 @@ function selectFileToOpen(path) {
       .then((resp) => {
         console.log('response is SELECT_FILE_TO_OPEN:', resp);
 
-        dispatch(profiler.getProfile());
+        // dispatch(profiler.getProfile());
         dispatch(histogramActions.getHistogramData());
         dispatch(gridControl.getDataGrid());
         dispatch(imageStatsActions.getImageStats());
         dispatch(colormap.updateColormap());
+        // dispatch(profiler.getCurveData());
         return dispatch(imageViewer.updateStack());
       })
       .then((stack) => {

--- a/imports/fileBrowser/actions.js
+++ b/imports/fileBrowser/actions.js
@@ -89,6 +89,7 @@ function closeFile() {
             dispatch(colormap.updateColormap());
             dispatch(imageStatsActions.getImageStats());
             dispatch(animator.updateAnimator(resp));
+            dispatch(profiler.autoGenerate());
           });
       } else {
         console.log('no stack layer to close');

--- a/imports/fileBrowser/actions.js
+++ b/imports/fileBrowser/actions.js
@@ -135,6 +135,7 @@ function selectFileToOpen(path) {
         console.log('response is SELECT_FILE_TO_OPEN:', resp);
 
         // dispatch(profiler.getProfile());
+        dispatch(profiler.autoGenerate());
         dispatch(histogramActions.getHistogramData());
         dispatch(gridControl.getDataGrid());
         dispatch(imageStatsActions.getImageStats());

--- a/imports/profiler/Profiler.js
+++ b/imports/profiler/Profiler.js
@@ -131,14 +131,20 @@ class Profiler extends Component {
   updateChannelFrame = (animatorTypeList, profileData) => {
     let channelIndicator = 0;
     if (animatorTypeList && profileData.length > 0) {
-      const { x } = profileData[0];
-      for(const animatorType of animatorTypeList) {
-        if(x && animatorType.type === 'Channel') {
-          // TODO: This one should follow the current image
-          // channelIndicator = x[animatorType.selection.frame];
-          channelIndicator = animatorType.selection.frame;
-        }
-      }
+      const imageAnimator = animatorTypeList.find((element) => {
+        return element.type === 'Image';
+      });
+      const channelAnimator = animatorTypeList.find((element) => {
+        return element.type === 'Channel';
+      });
+      const { selection } = imageAnimator;
+      const { fileList } = selection;
+      const imageName = fileList[selection.frame];
+      const currentProfile = profileData.find((element) => {
+        return element.id.includes(imageName);
+      });
+      const { x } = currentProfile;
+      channelIndicator = x[channelAnimator.selection.frame];
     }
     let layout = {};
     if (channelIndicator !== undefined) {

--- a/imports/profiler/Profiler.js
+++ b/imports/profiler/Profiler.js
@@ -204,9 +204,10 @@ class Profiler extends Component {
             <SelectField
               floatingLabelText="Auto Mode"
               value={this.props.profilerSetting.genMode}
-              // onChange={(event, index, value) => {
-              //   this.setState({ selectedCurve: value });
-              // }}
+              disabled={!this.props.profilerSetting.autoGenerate}
+              onChange={(event, index, value) => {
+                this.props.dispatch(actions.setGenerationMode(value));
+              }}
               autoWidth
               style={{ width: '150px', margin: '10px', verticalAlign: 'middle' }}
             >

--- a/imports/profiler/Profiler.js
+++ b/imports/profiler/Profiler.js
@@ -19,8 +19,6 @@ class Profiler extends Component {
     this.state = {
       saveAsInput: '',
       src: '',
-      // TODO: don't use react state, move to mongo
-      selectedCurve: '',
     };
     this.props.dispatch(actions.setupProfiler());
     // this.getRef = this.getRef.bind(this);
@@ -187,9 +185,9 @@ class Profiler extends Component {
         </button>
         <SelectField
           floatingLabelText="Selected Curve"
-          value={this.state.selectedCurve}
+          value={this.props.profilerSettings.selectCurve}
           onChange={(event, index, value) => {
-            this.setState({ selectedCurve: value });
+            this.props.dispatch(actions.setSelectedCurve(value));
           }}
           autoWidth
           style={{ width: '150px', margin: '10px', verticalAlign: 'middle' }}
@@ -270,9 +268,7 @@ class Profiler extends Component {
               disabled={this.props.profilerSettings.autoGenerate}
               // style={{ position: 'absolute', right: '23px', bottom: 0 }}
               onClick={() => {
-                console.log(this.state.selectedCurve);
-                const index = curveNameList.indexOf(this.state.selectedCurve);
-                this.props.dispatch(actions.removeProfile(index));
+                this.props.dispatch(actions.removeProfile());
               }}
             >
               Delete Profile

--- a/imports/profiler/Profiler.js
+++ b/imports/profiler/Profiler.js
@@ -46,9 +46,13 @@ class Profiler extends Component {
       }
     });
   }
-  plotProfile = (profileData, layout) => {
+  plotProfile = (profileData, fitData, layout) => {
     if (profileData && layout) {
       Plotly.newPlot(this.el, profileData, layout);
+      if (fitData) {
+        console.log('**********TRY TO ADD TRACE*********', fitData);
+        Plotly.addTraces(this.el, fitData);
+      }
       this.el.on('plotly_hover', (e) => {
         this.props.dispatch(actions.onHover(e));
       });
@@ -139,11 +143,13 @@ class Profiler extends Component {
       const { fileList } = selection;
       const imageName = fileList[selection.frame];
       const currentProfile = profileData.find((element) => {
-        return element.id.includes(imageName);
+        return element.id && element.id.includes(imageName);
       });
-      const { x } = currentProfile;
-      if (x) {
-        channelIndicator = x[channelAnimator.selection.frame];
+      if (currentProfile) {
+        const { x } = currentProfile;
+        if (x) {
+          channelIndicator = x[channelAnimator.selection.frame];
+        }
       }
     }
     let layout = {};
@@ -170,10 +176,12 @@ class Profiler extends Component {
   }
 
   render() {
-    const { animatorTypeList, profileData, width, data, zoomPanData } = this.props;
+    console.log('RENDER PROPS: ', this.props);
+    
+    const { animatorTypeList, profileData, fitData, width, data, zoomPanData } = this.props;
     const layout = { height: 395 };
     if (this.el) {
-      this.plotProfile(profileData, layout);
+      this.plotProfile(profileData, fitData, layout);
       this.updateChannelFrame(animatorTypeList, profileData);
       if (width) {
         this.adjustChartWidth();
@@ -186,7 +194,6 @@ class Profiler extends Component {
       }
     }
 
-    console.log('RENDER PROPS: ', this.props);
     const curveNameList = [];
     if (profileData) {
       profileData.forEach((element) => {
@@ -314,5 +321,6 @@ const mapStateToProps = state => ({
   zoomPanData: state.ProfilerDB.zoomPanData,
   profilerSettings: state.ProfilerDB.profilerSettings,
   animatorTypeList: state.AnimatorDB.animatorTypeList,
+  fitData: state.ProfilerDB.fitData,
 });
 export default connect(mapStateToProps)(Profiler);

--- a/imports/profiler/Profiler.js
+++ b/imports/profiler/Profiler.js
@@ -199,8 +199,21 @@ class Profiler extends Component {
               label="Auto Generate"
               // style={{ width: 150 }}
               checked={this.props.profilerSetting.autoGenerate}
-              onCheck={() => { this.props.dispatch(actions.setAutoGen()); }}
+              onCheck={() => { this.props.dispatch(actions.setAutoGen(!this.props.profilerSetting.autoGenerate)); }}
             />
+            <SelectField
+              floatingLabelText="Auto Mode"
+              value={this.props.profilerSetting.genMode}
+              // onChange={(event, index, value) => {
+              //   this.setState({ selectedCurve: value });
+              // }}
+              autoWidth
+              style={{ width: '150px', margin: '10px', verticalAlign: 'middle' }}
+            >
+              {/* TODO: don't use the hard-code menu item */}
+              <MenuItem value="Current" primaryText="Current"/>
+              <MenuItem value="All" primaryText="All"/>
+            </SelectField>
           </div>
           <div style={{ flex: 1 }}>
             <button

--- a/imports/profiler/Profiler.js
+++ b/imports/profiler/Profiler.js
@@ -130,10 +130,50 @@ class Profiler extends Component {
       });
     });
   }
+
+  updateChannelFrame = (animatorTypeList, profileData) => {
+    let channelIndicator = 0;
+    if (animatorTypeList && profileData.length > 0) {
+      const { x } = profileData[0];
+      for(const animatorType of animatorTypeList) {
+        if(x && animatorType.type === 'Channel') {
+          // TODO: This one should follow the current image
+          // channelIndicator = x[animatorType.selection.frame];
+          channelIndicator = animatorType.selection.frame;
+        }
+      }
+    }
+    let layout = {};
+    if (channelIndicator !== undefined) {
+      layout = {
+        shapes: [{
+          type: 'line',
+          x0: channelIndicator,
+          y0: 0,
+          x1: channelIndicator,
+          yref: 'paper',
+          y1: 1,
+          line: {
+            color: 'red',
+            width: 1.5,
+            // dash: 'dot',
+          },
+        }],
+      };
+    }
+    if (this.el !== undefined) {
+      Plotly.relayout(this.el, layout);
+    }
+  }
+
   render() {
+
+    const { animatorTypeList, profileData } = this.props;
+    this.updateChannelFrame(animatorTypeList, profileData);
+
     console.log('RENDER PROPS: ', this.props);
     const curveNameList = [];
-    const { profileData } = this.props;
+    // const { profileData } = this.props;
     for (let i = 0; i < profileData.length; i += 1) {
       // curveNameList.push(
       //   <MenuItem value={profileData[i].name} primaryText={profileData[i].name} key={i} />);
@@ -198,13 +238,13 @@ class Profiler extends Component {
             <Checkbox
               label="Auto Generate"
               // style={{ width: 150 }}
-              checked={this.props.profilerSetting.autoGenerate}
-              onCheck={() => { this.props.dispatch(actions.setAutoGen(!this.props.profilerSetting.autoGenerate)); }}
+              checked={this.props.profilerSettings.autoGenerate}
+              onCheck={() => { this.props.dispatch(actions.setAutoGen(!this.props.profilerSettings.autoGenerate)); }}
             />
             <SelectField
               floatingLabelText="Auto Mode"
-              value={this.props.profilerSetting.genMode}
-              disabled={!this.props.profilerSetting.autoGenerate}
+              value={this.props.profilerSettings.genMode}
+              disabled={!this.props.profilerSettings.autoGenerate}
               onChange={(event, index, value) => {
                 this.props.dispatch(actions.setGenerationMode(value));
               }}
@@ -218,7 +258,7 @@ class Profiler extends Component {
           </div>
           <div style={{ flex: 1 }}>
             <button
-              disabled={this.props.profilerSetting.autoGenerate}
+              disabled={this.props.profilerSettings.autoGenerate}
               // style={{ position: 'absolute', right: '23px', bottom: 0 }}
               onClick={() => { this.props.dispatch(actions.newProfile()); }}
             >
@@ -227,7 +267,7 @@ class Profiler extends Component {
           </div>
           <div style={{ flex: 1 }}>
             <button
-              disabled={this.props.profilerSetting.autoGenerate}
+              disabled={this.props.profilerSettings.autoGenerate}
               // style={{ position: 'absolute', right: '23px', bottom: 0 }}
               onClick={() => {
                 console.log(this.state.selectedCurve);
@@ -247,6 +287,7 @@ const mapStateToProps = state => ({
   profileData: state.ProfilerDB.profileData,
   data: state.ProfilerDB.data,
   zoomPanData: state.ProfilerDB.zoomPanData,
-  profilerSetting: state.ProfilerDB.profilerSetting,
+  profilerSettings: state.ProfilerDB.profilerSettings,
+  animatorTypeList: state.AnimatorDB.animatorTypeList,
 });
 export default connect(mapStateToProps)(Profiler);

--- a/imports/profiler/Profiler.js
+++ b/imports/profiler/Profiler.js
@@ -278,6 +278,17 @@ class Profiler extends Component {
               Delete Profile
             </button>
           </div>
+          <div style={{ flex: 1 }}>
+            <button
+              // disabled={this.props.profilerSettings.autoGenerate}
+              // style={{ position: 'absolute', right: '23px', bottom: 0 }}
+              onClick={() => {
+                this.props.dispatch(actions.clearProfiles());
+              }}
+            >
+              Clear Profile
+            </button>
+          </div>
         </div>
       </div>
     );

--- a/imports/profiler/Profiler.js
+++ b/imports/profiler/Profiler.js
@@ -132,7 +132,8 @@ class Profiler extends Component {
 
   updateChannelFrame = (animatorTypeList, profileData) => {
     let channelIndicator = 0;
-    if (animatorTypeList && profileData && profileData.length > 0) {
+    if (animatorTypeList && animatorTypeList.imageAnimator && animatorTypeList.channelAnimator &&
+        profileData && profileData.length > 0) {
       const imageAnimator = animatorTypeList.find((element) => {
         return element.type === 'Image';
       });

--- a/imports/profiler/Profiler.js
+++ b/imports/profiler/Profiler.js
@@ -172,16 +172,18 @@ class Profiler extends Component {
   render() {
     const { animatorTypeList, profileData, width, data, zoomPanData } = this.props;
     const layout = { height: 395 };
-    this.plotProfile(profileData, layout);
-    this.updateChannelFrame(animatorTypeList, profileData);
-    if (width && this.el) {
-      this.adjustChartWidth();
-    }
-    if (profileData && profileData.length > 0 && data) {
-      this.relayoutOnHover();
-    }
-    if (zoomPanData) {
-      this.relayoutOnZoomPan();
+    if (this.el) {
+      this.plotProfile(profileData, layout);
+      this.updateChannelFrame(animatorTypeList, profileData);
+      if (width) {
+        this.adjustChartWidth();
+      }
+      if (profileData && profileData.length > 0 && data) {
+        this.relayoutOnHover();
+      }
+      if (zoomPanData) {
+        this.relayoutOnZoomPan();
+      }
     }
 
     console.log('RENDER PROPS: ', this.props);

--- a/imports/profiler/Profiler.js
+++ b/imports/profiler/Profiler.js
@@ -9,7 +9,6 @@ import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import TextField from 'material-ui/TextField';
 import actions from './actions';
-import { log } from 'util';
 // import api from '../api/ApiService';
 
 // const d3 = Plotly.d3;
@@ -167,7 +166,6 @@ class Profiler extends Component {
   }
 
   render() {
-
     const { animatorTypeList, profileData } = this.props;
     this.updateChannelFrame(animatorTypeList, profileData);
 
@@ -180,7 +178,7 @@ class Profiler extends Component {
       curveNameList.push(profileData[i].name);
     }
     const curveNameMenuItem = curveNameList.map(item => (
-      <MenuItem value={item} primaryText={item}/>
+      <MenuItem value={item} primaryText={item} />
     ));
     return (
       <div>
@@ -239,7 +237,9 @@ class Profiler extends Component {
               label="Auto Generate"
               // style={{ width: 150 }}
               checked={this.props.profilerSettings.autoGenerate}
-              onCheck={() => { this.props.dispatch(actions.setAutoGen(!this.props.profilerSettings.autoGenerate)); }}
+              onCheck={() => {
+                this.props.dispatch(actions.setAutoGen(!this.props.profilerSettings.autoGenerate));
+              }}
             />
             <SelectField
               floatingLabelText="Auto Mode"
@@ -252,8 +252,8 @@ class Profiler extends Component {
               style={{ width: '150px', margin: '10px', verticalAlign: 'middle' }}
             >
               {/* TODO: don't use the hard-code menu item */}
-              <MenuItem value="Current" primaryText="Current"/>
-              <MenuItem value="All" primaryText="All"/>
+              <MenuItem value="Current" primaryText="Current" />
+              <MenuItem value="All" primaryText="All" />
             </SelectField>
           </div>
           <div style={{ flex: 1 }}>

--- a/imports/profiler/actions.js
+++ b/imports/profiler/actions.js
@@ -49,7 +49,7 @@ function setupProfiler() {
           .then((response) => {
             console.log('Try to get the setting of profiler!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!', response);
             const profilerSettings = response.data;
-            mongoUpsert(ProfilerDB, { profilerSettings, profileData: [] }, 'getProfilerSettings');
+            mongoUpsert(ProfilerDB, { profilerSettings }, 'getProfilerSettings');
           })
           .then(() => {
             parseRegisterProfilerResp(resp);

--- a/imports/profiler/actions.js
+++ b/imports/profiler/actions.js
@@ -266,6 +266,22 @@ function setFitCurves(value) {
   };
 }
 
+function setGaussCount(value) {
+  return (dispatch, getState) => {
+    const { profilerID } = getState().ProfilerDB;
+    const cmd = `${profilerID}:setGaussCount`;
+    api.instance().sendCommand(cmd, value)
+      .then((resp) => {
+        const { fit } = resp.data;
+        mongoUpsert(ProfilerDB, { fit }, 'SET_GAUSS_COUNT');
+      })
+      .then(() => {
+        dispatch(getProfile());
+        dispatch(getFitStatistics());
+      });
+  };
+}
+
 function setGenerationMode(mode) {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
@@ -368,6 +384,16 @@ function setShowGridLines(value) {
   };
 }
 
+function setShowStatistics(value) {
+  return (dispatch, getState) => {
+    const { profilerSettings } = getState().ProfilerDB;
+    // profilerSettings.gridLines = value;
+    const data = { ...profilerSettings };
+    data.showStats = value;
+    mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_SELECTED_CURVE');
+  };
+}
+
 function setZoomRange(zoomMin, zoomMax) {
   return (dispatch, getState) => {
     const { profilerSettings } = getState().ProfilerDB;
@@ -440,6 +466,7 @@ const actions = {
   setAxisUnitsLeft,
   setAxisUnitsBottom,
   setFitCurves,
+  setGaussCount,
   setGenerationMode,
   setLegendShow,
   setLegendExternal,
@@ -450,6 +477,7 @@ const actions = {
   setShowCursor,
   setShowFrame,
   setShowGridLines,
+  setShowStatistics,
   setZoomRange,
   setZoomRangePercent,
 };

--- a/imports/profiler/actions.js
+++ b/imports/profiler/actions.js
@@ -118,8 +118,33 @@ function getCurveData() {
   };
 }
 
-function setAutoGen() {
+function autoGenerate() {
   return (dispatch, getState) => {
+    const { profilerID } = getState().ProfilerDB;
+    if (profilerID) {
+      const cmd = `${profilerID}:newProfile`;
+      const params = '';
+      api.instance().sendCommand(cmd, params)
+        .then((resp) => {
+          const { curves } = resp.data;
+          mongoUpsert(ProfilerDB, { profileData: curves }, 'AUTO_GENERATE');
+        });
+    }
+  };
+}
+
+function setAutoGen(value) {
+  return (dispatch, getState) => {
+    const { profilerID } = getState().ProfilerDB;
+    const cmd = `${profilerID}:setAutoGenerate`;
+    api.instance().sendCommand(cmd, value)
+      .then((resp) => {
+        const { data } = resp;
+        mongoUpsert(ProfilerDB, { profilerSetting: data }, 'SET_PROFILERSETTING');
+      })
+      .then(() => {
+        dispatch(autoGenerate());
+      });
     // only for test, not implement
     // const { autoGen } = getState().ProfilerDB;
     // const value = !autoGen;
@@ -171,6 +196,7 @@ const actions = {
   newProfile,
   setAutoGen,
   removeProfile,
+  autoGenerate,
 };
 
 export default actions;

--- a/imports/profiler/actions.js
+++ b/imports/profiler/actions.js
@@ -76,7 +76,8 @@ function getProfile() {
     api.instance().sendCommand(cmd, params, (resp) => {
       // console.log('get response of profile:', resp);
       console.log('PROFILE DATA: ', resp.data);
-      mongoUpsert(ProfilerDB, { profileData: resp.data }, SET_PROFILEDATA);
+      const { curves } = resp.data;
+      mongoUpsert(ProfilerDB, { profileData: curves }, SET_PROFILEDATA);
     });
   };
 }
@@ -192,6 +193,36 @@ function setAutoGen(value) {
   };
 }
 
+function setAxisUnitsLeft(value) {
+  return (dispatch, getState) => {
+    const { profilerID } = getState().ProfilerDB;
+    const cmd = `${profilerID}:setAxisUnitsLeft`;
+    api.instance().sendCommand(cmd, value)
+      .then((resp) => {
+        const { data } = resp;
+        mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_PROFILERSETTING');
+      })
+      .then(() => {
+        dispatch(getProfile());
+      });
+  };
+}
+
+function setAxisUnitsBottom(value) {
+  return (dispatch, getState) => {
+    const { profilerID } = getState().ProfilerDB;
+    const cmd = `${profilerID}:setAxisUnitsBottom`;
+    api.instance().sendCommand(cmd, value)
+      .then((resp) => {
+        const { data } = resp;
+        mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_PROFILERSETTING');
+      })
+      .then(() => {
+        dispatch(getProfile());
+      });
+  };
+}
+
 function setGenerationMode(mode) {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
@@ -204,6 +235,42 @@ function setGenerationMode(mode) {
       .then(() => {
         dispatch(autoGenerate());
       });
+  };
+}
+
+function setLegendExternal(value) {
+  return (dispatch, getState) => {
+    const { profilerSettings } = getState().ProfilerDB;
+    const data = { ...profilerSettings };
+    data.legendExternal = value;
+    mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_SELECTED_CURVE');
+  };
+}
+
+function setLegendLine(value) {
+  return (dispatch, getState) => {
+    const { profilerSettings } = getState().ProfilerDB;
+    const data = { ...profilerSettings };
+    data.legendLine = value;
+    mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_SELECTED_CURVE');
+  };
+}
+
+function setLegendLocation(value) {
+  return (dispatch, getState) => {
+    const { profilerSettings } = getState().ProfilerDB;
+    const data = { ...profilerSettings };
+    data.legendLocation = value;
+    mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_SELECTED_CURVE');
+  };
+}
+
+function setLegendShow(value) {
+  return (dispatch, getState) => {
+    const { profilerSettings } = getState().ProfilerDB;
+    const data = { ...profilerSettings };
+    data.legendShow = value;
+    mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_SELECTED_CURVE');
   };
 }
 
@@ -222,6 +289,39 @@ function setSelectedCurve(id) {
         const { data } = resp;
         mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_SELECTED_CURVE');
       });
+  };
+}
+
+// TODO: The following list of functions do not have any function so far
+// They only change the initial value (from C++) saved in the mongoDB
+// They should call some function to change the layout of plotly.
+// List: setShowCursor, setShowFrame, setShowGridLines
+//       setLegendExternal, setLegendLine, setLegendLocation, setLegendShow
+function setShowCursor(value) {
+  return (dispatch, getState) => {
+    const { profilerSettings } = getState().ProfilerDB;
+    const data = { ...profilerSettings };
+    data.showCursor = value;
+    mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_SELECTED_CURVE');
+  };
+}
+
+function setShowFrame(value) {
+  return (dispatch, getState) => {
+    const { profilerSettings } = getState().ProfilerDB;
+    const data = { ...profilerSettings };
+    data.showFrame = value;
+    mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_SELECTED_CURVE');
+  };
+}
+
+function setShowGridLines(value) {
+  return (dispatch, getState) => {
+    const { profilerSettings } = getState().ProfilerDB;
+    // profilerSettings.gridLines = value;
+    const data = { ...profilerSettings };
+    data.gridLines = value;
+    mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_SELECTED_CURVE');
   };
 }
 
@@ -271,9 +371,18 @@ const actions = {
   newProfile,
   removeProfile,
   setAutoGen,
+  setAxisUnitsLeft,
+  setAxisUnitsBottom,
   setGenerationMode,
+  setLegendShow,
+  setLegendExternal,
+  setLegendLine,
+  setLegendLocation,
   setProfilerMainSetting,
   setSelectedCurve,
+  setShowCursor,
+  setShowFrame,
+  setShowGridLines,
 };
 
 export default actions;

--- a/imports/profiler/actions.js
+++ b/imports/profiler/actions.js
@@ -93,9 +93,9 @@ function getFitData() {
     const params = '';
     api.instance().sendCommand(cmd, params)
       .then((resp) => {
-        const { fit } = resp.data;
-        mongoUpsert(ProfilerDB, { fit }, 'GET_FIT_DATA');
-        // console.log('FIT_DATA:', resp.data);
+        const { fit, x, y } = resp.data;
+        const fitData = [{ x, y }];
+        mongoUpsert(ProfilerDB, { fit, fitData }, 'GET_FIT_DATA');
       });
   };
 }
@@ -262,6 +262,9 @@ function setFitCurves(value) {
     api.instance().sendCommand(cmd, params)
       .then(() => {
         dispatch(getProfile());
+      })
+      .then(() => {
+        dispatch(getFitData());
       });
   };
 }
@@ -277,6 +280,7 @@ function setGaussCount(value) {
       })
       .then(() => {
         dispatch(getProfile());
+        dispatch(getFitData());
         dispatch(getFitStatistics());
       });
   };

--- a/imports/profiler/actions.js
+++ b/imports/profiler/actions.js
@@ -121,7 +121,8 @@ function getCurveData() {
 function autoGenerate() {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    if (profilerID) {
+    const { profilerSetting } = getState().ProfilerDB;
+    if (profilerID && profilerSetting.autoGenerate) {
       const cmd = `${profilerID}:newProfile`;
       const params = '';
       api.instance().sendCommand(cmd, params)
@@ -149,6 +150,21 @@ function setAutoGen(value) {
     // const { autoGen } = getState().ProfilerDB;
     // const value = !autoGen;
     // mongoUpsert(ProfilerDB, { autoGen: value }, 'TEST');
+  };
+}
+
+function setGenerationMode(mode) {
+  return (dispatch, getState) => {
+    const { profilerID } = getState().ProfilerDB;
+    const cmd = `${profilerID}:setGenerationMode`;
+    api.instance().sendCommand(cmd, mode)
+      .then((resp) => {
+        const { data } = resp;
+        mongoUpsert(ProfilerDB, { profilerSetting: data }, 'SET_PROFILERSETTING');
+      })
+      .then(() => {
+        dispatch(autoGenerate());
+      });
   };
 }
 
@@ -197,6 +213,7 @@ const actions = {
   setAutoGen,
   removeProfile,
   autoGenerate,
+  setGenerationMode,
 };
 
 export default actions;

--- a/imports/profiler/actions.js
+++ b/imports/profiler/actions.js
@@ -43,17 +43,17 @@ function setupProfiler() {
     api.instance().sendCommand(cmd, params)
       .then((resp) => {
         const profilerID = resp.data;
-        const command = `${profilerID}:getProfilerSettings`;
+        const command = `${profilerID}:${Commands.GET_PROFILER_SETTINGS}`;
         const parameters = '';
         api.instance().sendCommand(command, parameters)
           .then((response) => {
             console.log('Try to get the setting of profiler!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!', response);
             const profilerSettings = response.data;
-            mongoUpsert(ProfilerDB, { profilerSettings }, 'getProfilerSettings');
+            mongoUpsert(ProfilerDB, { profilerID, profilerSettings }, 'getProfilerSettings');
           })
-          .then(() => {
-            parseRegisterProfilerResp(resp);
-          })
+          // .then(() => {
+          //   parseRegisterProfilerResp(resp);
+          // })
           .then(() => {
             dispatch(getFitData());
             dispatch(getFitStatistics());
@@ -62,19 +62,19 @@ function setupProfiler() {
   };
 }
 
-function clearProfile() {
-  return (dispatch) => {
-    const data = { x: [], y: [] };
-    mongoUpsert(ProfilerDB, { profileData: data }, SET_PROFILEDATA);
-  };
-}
+// function clearProfile() {
+//   return (dispatch) => {
+//     const data = { x: [], y: [] };
+//     mongoUpsert(ProfilerDB, { profileData: data }, SET_PROFILEDATA);
+//   };
+// }
 
 function getProfile() {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
     // console.log('profilerID for getting profile: ', profilerID);
 
-    const cmd = `${profilerID}:getProfileData`;
+    const cmd = `${profilerID}:${Commands.GET_PROFILE_DATA}`;
     const params = '';
 
     api.instance().sendCommand(cmd, params, (resp) => {
@@ -89,7 +89,7 @@ function getProfile() {
 function getFitData() {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    const cmd = `${profilerID}:getFitData`;
+    const cmd = `${profilerID}:${Commands.GET_FIT_DATA}`;
     const params = '';
     api.instance().sendCommand(cmd, params)
       .then((resp) => {
@@ -103,7 +103,7 @@ function getFitData() {
 function getFitStatistics() {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    const cmd = `${profilerID}:getFitStatistics`;
+    const cmd = `${profilerID}:${Commands.GET_FIT_STATISTICS}`;
     const params = '';
     api.instance().sendCommand(cmd, params)
       .then((resp) => {
@@ -131,7 +131,7 @@ function autoGenerate() {
     const { profilerID } = getState().ProfilerDB;
     const { profilerSettings } = getState().ProfilerDB;
     if (profilerID && profilerSettings.autoGenerate) {
-      const cmd = `${profilerID}:newProfile`;
+      const cmd = `${profilerID}:${Commands.NEW_PROFILE}`;
       const params = '';
       api.instance().sendCommand(cmd, params)
         .then((resp) => {
@@ -148,7 +148,7 @@ function autoGenerate() {
 function clearProfiles() {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    const cmd = `${profilerID}:clearProfiles`;
+    const cmd = `${profilerID}:${Commands.CLEAR_PROFILES}`;
     const params = '';
     api.instance().sendCommand(cmd, params)
       .then((resp) => {
@@ -161,7 +161,7 @@ function clearProfiles() {
 function getProfilerSettings() {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    const cmd = `${profilerID}:getProfilerSettings`;
+    const cmd = `${profilerID}:${Commands.GET_PROFILER_SETTINGS}`;
     const params = '';
     api.instance().sendCommand(cmd, params)
       .then((resp) => {
@@ -175,7 +175,7 @@ function newProfile() {
   return (dispatch, getState) => {
     console.log('*******************************************************************');
     const { profilerID } = getState().ProfilerDB;
-    const cmd = `${profilerID}:newProfile`;
+    const cmd = `${profilerID}:${Commands.NEW_PROFILE}`;
     const params = '';
     api.instance().sendCommand(cmd, params)
       .then((resp) => {
@@ -192,7 +192,7 @@ function newProfile() {
 function removeProfile() {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    const cmd = `${profilerID}:removeProfile`;
+    const cmd = `${profilerID}:${Commands.REMOVE_PROFILE}`;
     const params = '';
     api.instance().sendCommand(cmd, params)
       .then((resp) => {
@@ -208,7 +208,7 @@ function removeProfile() {
 function setAutoGen(value) {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    const cmd = `${profilerID}:setAutoGenerate`;
+    const cmd = `${profilerID}:${Commands.SET_AUTO_GENERATE}`;
     api.instance().sendCommand(cmd, value)
       .then((resp) => {
         const { data } = resp;
@@ -227,7 +227,7 @@ function setAutoGen(value) {
 function setAxisUnitsLeft(value) {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    const cmd = `${profilerID}:setAxisUnitsLeft`;
+    const cmd = `${profilerID}:${Commands.SET_AXIS_UNITS_LEFT}`;
     api.instance().sendCommand(cmd, value)
       .then((resp) => {
         const { data } = resp;
@@ -242,7 +242,7 @@ function setAxisUnitsLeft(value) {
 function setAxisUnitsBottom(value) {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    const cmd = `${profilerID}:setAxisUnitsBottom`;
+    const cmd = `${profilerID}:${Commands.SET_AXIS_UNITS_BOTTOM}`;
     api.instance().sendCommand(cmd, value)
       .then((resp) => {
         const { data } = resp;
@@ -257,7 +257,7 @@ function setAxisUnitsBottom(value) {
 function setFitCurves(value) {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    const cmd = `${profilerID}:setFitCurves`;
+    const cmd = `${profilerID}:${Commands.SET_FIT_CURVES}`;
     const params = value.toString();
     api.instance().sendCommand(cmd, params)
       .then(() => {
@@ -272,7 +272,7 @@ function setFitCurves(value) {
 function setGaussCount(value) {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    const cmd = `${profilerID}:setGaussCount`;
+    const cmd = `${profilerID}:${Commands.SET_GAUSS_COUNT}`;
     api.instance().sendCommand(cmd, value)
       .then((resp) => {
         const { fit } = resp.data;
@@ -289,7 +289,7 @@ function setGaussCount(value) {
 function setGenerationMode(mode) {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    const cmd = `${profilerID}:setGenerationMode`;
+    const cmd = `${profilerID}:${Commands.SET_GENERATION_MODE}`;
     api.instance().sendCommand(cmd, mode)
       .then((resp) => {
         const { data } = resp;
@@ -346,7 +346,7 @@ function setProfilerMainSetting(value) {
 function setSelectedCurve(id) {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    const cmd = `${profilerID}:setSelectedCurve`;
+    const cmd = `${profilerID}:${Commands.SET_SELECTED_CURVE}`;
     api.instance().sendCommand(cmd, id)
       .then((resp) => {
         const { data } = resp;
@@ -456,7 +456,7 @@ const actions = {
   onHover,
   onZoomPan,
   getProfile,
-  clearProfile,
+  // clearProfile,
   getCurveData,
 
   autoGenerate,

--- a/imports/profiler/actions.js
+++ b/imports/profiler/actions.js
@@ -54,6 +54,19 @@ function setupProfiler() {
   };
 }
 
+function getProfilerSettings() {
+  return (dispatch, getState) => {
+    const { profilerID } = getState().ProfilerDB;
+    const cmd = `${profilerID}:getProfilerSettings`;
+    const params = '';
+    api.instance().sendCommand(cmd, params)
+      .then((resp) => {
+        const { data } = resp;
+        mongoUpsert(ProfilerDB, { profilerSettings: data }, 'getProfilerSettings');
+      });
+  };
+}
+
 function setProfilerMainSetting(value) {
   return (dispatch, getState) => {
     mongoUpsert(ProfilerDB, { profilerMainSetting: value }, 'SET_PROFILER_MAIN_SETTING');
@@ -94,6 +107,9 @@ function newProfile() {
         console.log('Test to generate profile manually', resp);
         const { curves } = resp.data;
         mongoUpsert(ProfilerDB, { profileData: curves }, SET_PROFILEDATA);
+      })
+      .then(() => {
+        dispatch(getProfilerSettings());
       });
   };
 }
@@ -148,6 +164,9 @@ function autoGenerate() {
         .then((resp) => {
           const { curves } = resp.data;
           mongoUpsert(ProfilerDB, { profileData: curves }, 'AUTO_GENERATE');
+        })
+        .then(() => {
+          dispatch(getProfilerSettings());
         });
     }
   };
@@ -235,6 +254,7 @@ const actions = {
   setGenerationMode,
   setProfilerMainSetting,
   clearProfiles,
+  getProfilerSettings,
 };
 
 export default actions;

--- a/imports/profiler/actions.js
+++ b/imports/profiler/actions.js
@@ -54,6 +54,12 @@ function setupProfiler() {
   };
 }
 
+function setProfilerMainSetting(value) {
+  return (dispatch, getState) => {
+    mongoUpsert(ProfilerDB, { profilerMainSetting: value }, 'SET_PROFILER_MAIN_SETTING');
+  };
+}
+
 function clearProfile() {
   return (dispatch) => {
     const data = { x: [], y: [] };
@@ -214,6 +220,7 @@ const actions = {
   removeProfile,
   autoGenerate,
   setGenerationMode,
+  setProfilerMainSetting,
 };
 
 export default actions;

--- a/imports/profiler/actions.js
+++ b/imports/profiler/actions.js
@@ -325,6 +325,27 @@ function setShowGridLines(value) {
   };
 }
 
+function setZoomRange(zoomMin, zoomMax) {
+  return (dispatch, getState) => {
+    const { profilerSettings } = getState().ProfilerDB;
+    const data = { ...profilerSettings };
+    data.zoomMin = zoomMin;
+    data.zoomMax = zoomMax;
+    // console.log('******REPLACE PROFILERSETTING********', data);
+    mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_ZOOM');
+  };
+}
+
+function setZoomRangePercent(zoomMinPercent, zoomMaxPercent) {
+  return (dispatch, getState) => {
+    const { profilerSettings } = getState().ProfilerDB;
+    const data = { ...profilerSettings };
+    data.zoomMinPercent = zoomMinPercent;
+    data.zoomMaxPercent = zoomMaxPercent;
+    mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_ZOOM');
+  };
+}
+
 function onHover(data) {
   return () => {
     const val = {
@@ -339,11 +360,11 @@ function onZoomPan(data) {
   return () => {
     let val = null;
     val = {};
-    if (data['xaxis.range[0]']) {
+    if (data['xaxis.range[0]'] !== undefined) {
       // val['xaxis.range'] = [data['xaxis.range[0]'], data['xaxis.range[1]']];
       val.xRange = [data['xaxis.range[0]'], data['xaxis.range[1]']];
     }
-    if (data['yaxis.range[0]']) {
+    if (data['yaxis.range[0]'] !== undefined) {
       // val['yaxis.range'] = [data['yaxis.range[0]'], data['yaxis.range[1]']];
       val.yRange = [data['yaxis.range[0]'], data['yaxis.range[1]']];
     }
@@ -383,6 +404,8 @@ const actions = {
   setShowCursor,
   setShowFrame,
   setShowGridLines,
+  setZoomRange,
+  setZoomRangePercent,
 };
 
 export default actions;

--- a/imports/profiler/actions.js
+++ b/imports/profiler/actions.js
@@ -111,6 +111,19 @@ function removeProfile(value) {
   };
 }
 
+function clearProfiles() {
+  return (dispatch, getState) => {
+    const { profilerID } = getState().ProfilerDB;
+    const cmd = `${profilerID}:clearProfiles`;
+    const params = '';
+    api.instance().sendCommand(cmd, params)
+      .then((resp) => {
+        const { curves } = resp.data;
+        mongoUpsert(ProfilerDB, { profileData: curves }, SET_PROFILEDATA);
+      });
+  };
+}
+
 function getCurveData() {
   return (dispatch, getState) => {
     console.log('++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++');
@@ -221,6 +234,7 @@ const actions = {
   autoGenerate,
   setGenerationMode,
   setProfilerMainSetting,
+  clearProfiles,
 };
 
 export default actions;

--- a/imports/profiler/actions.js
+++ b/imports/profiler/actions.js
@@ -44,8 +44,8 @@ function setupProfiler() {
         api.instance().sendCommand(command, parameters)
           .then((response) => {
             console.log('Try to get the setting of profiler!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!', response);
-            const profilerSetting = response.data;
-            mongoUpsert(ProfilerDB, { profilerSetting, profileData: [] }, 'getProfilerSettings');
+            const profilerSettings = response.data;
+            mongoUpsert(ProfilerDB, { profilerSettings, profileData: [] }, 'getProfilerSettings');
           })
           .then(() => {
             parseRegisterProfilerResp(resp);
@@ -121,8 +121,8 @@ function getCurveData() {
 function autoGenerate() {
   return (dispatch, getState) => {
     const { profilerID } = getState().ProfilerDB;
-    const { profilerSetting } = getState().ProfilerDB;
-    if (profilerID && profilerSetting.autoGenerate) {
+    const { profilerSettings } = getState().ProfilerDB;
+    if (profilerID && profilerSettings.autoGenerate) {
       const cmd = `${profilerID}:newProfile`;
       const params = '';
       api.instance().sendCommand(cmd, params)
@@ -141,7 +141,7 @@ function setAutoGen(value) {
     api.instance().sendCommand(cmd, value)
       .then((resp) => {
         const { data } = resp;
-        mongoUpsert(ProfilerDB, { profilerSetting: data }, 'SET_PROFILERSETTING');
+        mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_PROFILERSETTING');
       })
       .then(() => {
         dispatch(autoGenerate());
@@ -160,7 +160,7 @@ function setGenerationMode(mode) {
     api.instance().sendCommand(cmd, mode)
       .then((resp) => {
         const { data } = resp;
-        mongoUpsert(ProfilerDB, { profilerSetting: data }, 'SET_PROFILERSETTING');
+        mongoUpsert(ProfilerDB, { profilerSettings: data }, 'SET_PROFILERSETTING');
       })
       .then(() => {
         dispatch(autoGenerate());

--- a/imports/profiler/profilerSettings/ProfilerCurveSetting.js
+++ b/imports/profiler/profilerSettings/ProfilerCurveSetting.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+class ProfilerCurveSetting extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <div>
+        <p>test5</p>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  // profilerMainSetting: state.ProfilerDB.profilerMainSetting,
+  profilerSettings: state.ProfilerDB.profilerSettings,
+});
+
+export default connect(mapStateToProps)(ProfilerCurveSetting);

--- a/imports/profiler/profilerSettings/ProfilerDisplaySetting.js
+++ b/imports/profiler/profilerSettings/ProfilerDisplaySetting.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+class ProfilerDisplaySetting extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <div>
+        <p>test1</p>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  // profilerMainSetting: state.ProfilerDB.profilerMainSetting,
+  profilerSettings: state.ProfilerDB.profilerSettings,
+});
+
+export default connect(mapStateToProps)(ProfilerDisplaySetting);

--- a/imports/profiler/profilerSettings/ProfilerDisplaySetting.js
+++ b/imports/profiler/profilerSettings/ProfilerDisplaySetting.js
@@ -37,7 +37,7 @@ class ProfilerDisplaySetting extends Component {
         >
           <MenuItem value="Radio Velocity(km/s)" primaryText="Radio Velocity(km/s)" />
           <MenuItem value="Optical Velocity(m/s)" primaryText="Optical Velocity(m/s)" />
-          <MenuItem value="Freguency(GHz)" primaryText="Freguency(GHz)" />
+          <MenuItem value="Frequency(GHz)" primaryText="Freguency(GHz)" />
           <MenuItem value="Wavelength(nm)" primaryText="Wavelength(nm)" />
           <MenuItem value="Air Wavelength(um)" primaryText="Air Wavelength(um)" />
           <MenuItem value="Channel" primaryText="Channel" />

--- a/imports/profiler/profilerSettings/ProfilerDisplaySetting.js
+++ b/imports/profiler/profilerSettings/ProfilerDisplaySetting.js
@@ -1,5 +1,9 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
+import Toggle from 'material-ui/Toggle';
+import actions from '../actions';
 
 class ProfilerDisplaySetting extends Component {
   constructor(props) {
@@ -8,9 +12,97 @@ class ProfilerDisplaySetting extends Component {
   }
 
   render() {
+    const { profilerSettings } = this.props;
     return (
       <div>
-        <p>test1</p>
+        <SelectField
+          floatingLabelText="Y Axis"
+          value={profilerSettings.axisUnitsLeft}
+          onChange={(event, index, value) => {
+            this.props.dispatch(actions.setAxisUnitsLeft(value));
+          }}
+        >
+          <MenuItem value="Jy/beam" primaryText="Jy/beam" />
+          <MenuItem value="Jy/pixel" primaryText="Jy/pixel" />
+          <MenuItem value="Jy/arcsec^2" primaryText="Jy/arcsec^2" />
+          <MenuItem value="MJy/sr" primaryText="MJy/sr" />
+          <MenuItem value="K" primaryText="K" />
+        </SelectField>
+        <SelectField
+          floatingLabelText="X Axis"
+          value={profilerSettings.axisUnitsBottom}
+          onChange={(event, index, value) => {
+            this.props.dispatch(actions.setAxisUnitsBottom(value));
+          }}
+        >
+          <MenuItem value="Radio Velocity(km/s)" primaryText="Radio Velocity(km/s)" />
+          <MenuItem value="Optical Velocity(m/s)" primaryText="Optical Velocity(m/s)" />
+          <MenuItem value="Freguency(GHz)" primaryText="Freguency(GHz)" />
+          <MenuItem value="Wavelength(nm)" primaryText="Wavelength(nm)" />
+          <MenuItem value="Air Wavelength(um)" primaryText="Air Wavelength(um)" />
+          <MenuItem value="Channel" primaryText="Channel" />
+        </SelectField>
+        <Toggle
+          label="Grid Lines"
+          toggled={profilerSettings.gridLines}
+          onToggle={(event, newValue) => {
+            this.props.dispatch(actions.setShowGridLines(newValue));
+          }}
+        />
+        <Toggle
+          label="Frame"
+          toggled={profilerSettings.showFrame}
+          onToggle={(event, newValue) => {
+            this.props.dispatch(actions.setShowFrame(newValue));
+          }}
+        />
+        <Toggle
+          label="Cursor"
+          toggled={profilerSettings.showCursor}
+          onToggle={(event, newValue) => {
+            this.props.dispatch(actions.setShowCursor(newValue));
+          }}
+        />
+        <Toggle
+          label="Legend"
+          toggled={profilerSettings.legendShow}
+          onToggle={(event, newValue) => {
+            this.props.dispatch(actions.setLegendShow(newValue));
+          }}
+        />
+        <Toggle
+          label="External Legend"
+          toggled={profilerSettings.legendExternal}
+          disabled={!profilerSettings.legendShow}
+          onToggle={(event, newValue) => {
+            this.props.dispatch(actions.setLegendExternal(newValue));
+          }}
+        />
+        <Toggle
+          label="Show Legend Line"
+          toggled={profilerSettings.legendLine}
+          disabled={!profilerSettings.legendShow}
+          onToggle={(event, newValue) => {
+            this.props.dispatch(actions.setLegendLine(newValue));
+          }}
+        />
+        <SelectField
+          floatingLabelText="Legend Location"
+          disabled={!profilerSettings.legendLine || !profilerSettings.legendShow}
+          value={profilerSettings.legendLocation}
+          onChange={(event, index, value) => {
+            this.props.dispatch(actions.setLegendLocation(value));
+          }}
+        >
+          <MenuItem value="Left" primaryText="Left" />
+          <MenuItem value="Right" primaryText="Right" />
+          <MenuItem value="Top" primaryText="Top" />
+          <MenuItem value="Bottom" primaryText="Bottom" />
+          <MenuItem value="Top Left" primaryText="Top Left" />
+          <MenuItem value="Top Right" primaryText="Top Right" />
+          <MenuItem value="Bottom Left" primaryText="Bottom Left" />
+          <MenuItem value="Bottom Right" primaryText="Bottom Right" />
+        </SelectField>
       </div>
     );
   }

--- a/imports/profiler/profilerSettings/ProfilerFitSetting.js
+++ b/imports/profiler/profilerSettings/ProfilerFitSetting.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+class ProfilerFitSetting extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <div>
+        <p>test4</p>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  // profilerMainSetting: state.ProfilerDB.profilerMainSetting,
+  profilerSettings: state.ProfilerDB.profilerSettings,
+});
+
+export default connect(mapStateToProps)(ProfilerFitSetting);

--- a/imports/profiler/profilerSettings/ProfilerFitSetting.js
+++ b/imports/profiler/profilerSettings/ProfilerFitSetting.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { List, ListItem } from 'material-ui/List';
-
 import SelectField from 'material-ui/SelectField';
 import MenuItem from 'material-ui/MenuItem';
 import Subheader from 'material-ui/Subheader';
@@ -81,9 +80,9 @@ class ProfilerFitSetting extends Component {
               min={0}
               max={100}
               value={fit.gaussCount}
-              // onChange={(event, value) => {
-              //   this.props.dispatch(actions.setFontSize(value));
-              // }}
+              onChange={(event, value) => {
+                this.props.dispatch(actions.setGaussCount(value));
+              }}
               style={numericInputStyle}
             />
           </div>
@@ -122,9 +121,9 @@ class ProfilerFitSetting extends Component {
         <Toggle
           label="Statistics"
           toggled={profilerSettings.showStats}
-          // onToggle={(event, newValue) => {
-          //   this.props.dispatch(actions.setLegendExternal(newValue));
-          // }}
+          onToggle={(event, newValue) => {
+            this.props.dispatch(actions.setShowStatistics(newValue));
+          }}
         />
         <Toggle
           label="Mean and RMS"
@@ -143,7 +142,10 @@ class ProfilerFitSetting extends Component {
         <Subheader>Statistics</Subheader>
         <Divider />
         <div>
-          {fitStats}
+          {/* {fitStats} */}
+          {/* TODO: a temporary solution to show fit statistics,
+          Try to reformat the m_stateFitStatistics in c++ */}
+          { profilerSettings.showStats && <td dangerouslySetInnerHTML={{__html: fitStats }} /> }
         </div>
         {/* <List>
           <Subheader>Select Curve to Fit</Subheader>

--- a/imports/profiler/profilerSettings/ProfilerFitSetting.js
+++ b/imports/profiler/profilerSettings/ProfilerFitSetting.js
@@ -1,5 +1,20 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { List, ListItem } from 'material-ui/List';
+
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
+import Subheader from 'material-ui/Subheader';
+import Divider from 'material-ui/Divider';
+import Checkbox from 'material-ui/Checkbox';
+import Toggle from 'material-ui/Toggle';
+import NumericInput from 'react-numeric-input';
+import actions from '../actions';
+
+const numericInputStyle = {
+  wrap: { height: '30px', width: '50px' },
+  input: { height: '30px', width: '50px' },
+};
 
 class ProfilerFitSetting extends Component {
   constructor(props) {
@@ -8,9 +23,139 @@ class ProfilerFitSetting extends Component {
   }
 
   render() {
+    const { profileData, profilerSettings, fit, fitStats } = this.props;
+    const curveNameList = [];
+    const selectFitCurves = [];
+    if (profileData) {
+      profileData.forEach((element) => {
+        curveNameList.push(element.name);
+      });
+      profileData.filter(element => element.fitSelect)
+        .forEach((element) => {
+          selectFitCurves.push(element.name);
+        });
+      // profileData.filter((element) => {
+      //   element.fitSelect
+      // }).forEach((element) => {
+      //   selectFitCurves.push(element.name);
+      // });
+    }
+    const curveNameMenuItem = curveNameList.map(item => (
+      <MenuItem
+        value={item}
+        primaryText={item}
+        checked={selectFitCurves && selectFitCurves.indexOf(item) > -1}
+      />
+    ));
+    // bug: https://github.com/mui-org/material-ui/issues/1357
+    // const curveNameListItem = curveNameList.map(item => (
+    //   <ListItem value={item} primaryText={item} 
+    //     leftCheckbox={<Checkbox />}
+    //     onClick={() => {
+    //       console.log('********************************', item);
+    //       // this.props.dispatch(actions.setFitCurves(value));
+    //     }}
+    //   />
+    // ));
     return (
       <div>
-        <p>test4</p>
+        <SelectField
+          multiple
+          floatingLabelText="Selected Curve for Fitting"
+          value={selectFitCurves}
+          onChange={(event, index, value) => {
+            this.props.dispatch(actions.setFitCurves(value));
+          }}
+        >
+          { curveNameMenuItem }
+        </SelectField>
+        <Subheader>Parameters</Subheader>
+        <Divider />
+        <div style={{ display: 'flex' }}>
+          <div style={{ flex: 'initial' }}>
+            {/* <Subheader>Gaussian Count:</Subheader> */}
+            <p>Gaussian Count:</p>
+          </div>
+          <div style={{ flex: 'initial' }}>
+            <NumericInput
+              min={0}
+              max={100}
+              value={fit.gaussCount}
+              // onChange={(event, value) => {
+              //   this.props.dispatch(actions.setFontSize(value));
+              // }}
+              style={numericInputStyle}
+            />
+          </div>
+          <div style={{ flex: 'initial' }}>
+            {/* <Subheader>Polynomial Term:</Subheader> */}
+            <p>Polynomial Term:</p>
+          </div>
+          <div style={{ flex: 'initial' }}>
+            <NumericInput
+              min={0}
+              max={100}
+              value={fit.polyDegree}
+              // onChange={(event, value) => {
+              //   this.props.dispatch(actions.setFontSize(value));
+              // }}
+              style={numericInputStyle}
+            />
+          </div>
+        </div>
+        <Toggle
+          label="Random Heuristic"
+          toggled={fit.heuristic}
+          // onToggle={(event, newValue) => {
+          //   this.props.dispatch(actions.setLegendExternal(newValue));
+          // }}
+        />
+        <Subheader>Display</Subheader>
+        <Divider />
+        <Toggle
+          label="Residual"
+          toggled={profilerSettings.showResiduals}
+          // onToggle={(event, newValue) => {
+          //   this.props.dispatch(actions.setLegendExternal(newValue));
+          // }}
+        />
+        <Toggle
+          label="Statistics"
+          toggled={profilerSettings.showStats}
+          // onToggle={(event, newValue) => {
+          //   this.props.dispatch(actions.setLegendExternal(newValue));
+          // }}
+        />
+        <Toggle
+          label="Mean and RMS"
+          toggled={profilerSettings.showMeanRMS}
+          // onToggle={(event, newValue) => {
+          //   this.props.dispatch(actions.setLegendExternal(newValue));
+          // }}
+        />
+        <Toggle
+          label="Peak Labels"
+          toggled={profilerSettings.showPeakLabels}
+          // onToggle={(event, newValue) => {
+          //   this.props.dispatch(actions.setLegendExternal(newValue));
+          // }}
+        />
+        <Subheader>Statistics</Subheader>
+        <Divider />
+        <div>
+          {fitStats}
+        </div>
+        {/* <List>
+          <Subheader>Select Curve to Fit</Subheader>
+          { curveNameListItem }
+          <ListItem value="test" primaryText="test" leftCheckbox={<Checkbox />}
+            onClick={(value) => {
+              console.log('********************************', value);
+              // this.props.dispatch(actions.setFitCurves(value));
+            }}
+          />
+        </List> */}
+        {/* <Divider /> */}
       </div>
     );
   }
@@ -19,6 +164,9 @@ class ProfilerFitSetting extends Component {
 const mapStateToProps = state => ({
   // profilerMainSetting: state.ProfilerDB.profilerMainSetting,
   profilerSettings: state.ProfilerDB.profilerSettings,
+  profileData: state.ProfilerDB.profileData,
+  fit: state.ProfilerDB.fit,
+  fitStats: state.ProfilerDB.fitStats,
 });
 
 export default connect(mapStateToProps)(ProfilerFitSetting);

--- a/imports/profiler/profilerSettings/ProfilerProfileSetting.js
+++ b/imports/profiler/profilerSettings/ProfilerProfileSetting.js
@@ -1,5 +1,12 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
+import Subheader from 'material-ui/Subheader';
+import SelectField from 'material-ui/SelectField';
+import MenuItem from 'material-ui/MenuItem';
+import RaisedButton from 'material-ui/RaisedButton';
+import TextField from 'material-ui/TextField';
+import actions from '../actions';
 
 class ProfilerProfileSetting extends Component {
   constructor(props) {
@@ -8,10 +15,98 @@ class ProfilerProfileSetting extends Component {
   }
 
   render() {
+    const { profilerSettings } = this.props;
+    const freqUnits = ['Hz', 'MHz', 'GHz'];
+    const wavelenUnits = ['mm', 'um', 'nm', 'Angstrom'];
+    let UnitsList = wavelenUnits.map(item => (
+      <MenuItem value={item} primaryText={item} />
+    ));
+    let restFreq = 'Wavelength';
+    if (profilerSettings.restFrequencyUnits) {
+      restFreq = 'Frequency';
+      UnitsList = freqUnits.map(item => (
+        <MenuItem value={item} primaryText={item} />
+      ));
+    }
     return (
       <div>
-        <p>test3</p>
+        <SelectField
+          floatingLabelText="Statistics"
+          value={profilerSettings.stat}
+          onChange={(event, index, value) => {
+            this.props.dispatch(actions.setStatistic(value));
+          }}
+        >
+          <MenuItem value="Mean" primaryText="Mean" />
+          <MenuItem value="Median" primaryText="Median" />
+          <MenuItem value="Sum" primaryText="Sum" />
+          <MenuItem value="Variance" primaryText="Variance" />
+          <MenuItem value="Minimum" primaryText="Minimum" />
+          <MenuItem value="Maximum" primaryText="Maximum" />
+          <MenuItem value="RMS" primaryText="RMS" />
+          <MenuItem value="Flux Density" primaryText="Flux Density" />
+        </SelectField>
+        <div style={{ display: 'flex' }}>
+          <div style={{ flex: 'initial' }}>
+            <SelectField
+              floatingLabelText="Rest Unit"
+              value={restFreq}
+              style={{ width: '100%' }}
+              // onChange={(event, index, value) => {
+              //   this.props.dispatch(actions.setStatistic(value));
+              // }}
+            >
+              <MenuItem value="Frequency" primaryText="Frequency" />
+              <MenuItem value="Wavelength" primaryText="Wavelength" />
+            </SelectField>
+          </div>
+          <div style={{ flex: 'initial' }}>
+            <TextField
+              floatingLabelText="Value"
+              style={{ width: '100%' }}
+              onChange={(event, newValue) => {
+                this.props.dispatch(actions.setTickLength(newValue));
+              }}
+              value={profilerSettings.restFrequency}
+            />
+          </div>
+          <div style={{ flex: 'initial' }}>
+            <SelectField
+              floatingLabelText="Unit"
+              value={profilerSettings.restUnits}
+              style={{ width: '100%' }}
+              // onChange={(event, index, value) => {
+              //   this.props.dispatch(actions.setStatistic(value));
+              // }}
+            >
+              { UnitsList }
+            </SelectField>
+          </div>
+          <div style={{ flex: 'initial' }}>
+            <RaisedButton label="Reset" style={{ margin: 12 }} />
+            {/* <button style={{ bottom: 0 }} > reset </button> */}
+          </div>
+        </div>
       </div>
+      // <div style={{ display: 'flex' }}>
+      //   <div style={{ flex: 'initial' }}>
+      //     <Subheader>Previous chats</Subheader>
+      //   </div>
+      //   <div style={{ flex: 'initial' }}>
+      //     <RadioButtonGroup name="shipSpeed" valueSelected={restFreq} style={{ display: 'flex', width: '60%' }}>
+      //       <RadioButton
+      //         value="freq"
+      //         label="Frequency"
+      //         // style={styles.radioButton}
+      //       />
+      //       <RadioButton
+      //         value="not_freq"
+      //         label="Wavelength"
+      //         // style={styles.radioButton}
+      //       />
+      //     </RadioButtonGroup>
+      //   </div>
+      // </div>
     );
   }
 }

--- a/imports/profiler/profilerSettings/ProfilerProfileSetting.js
+++ b/imports/profiler/profilerSettings/ProfilerProfileSetting.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+class ProfilerProfileSetting extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <div>
+        <p>test3</p>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  // profilerMainSetting: state.ProfilerDB.profilerMainSetting,
+  profilerSettings: state.ProfilerDB.profilerSettings,
+});
+
+export default connect(mapStateToProps)(ProfilerProfileSetting);

--- a/imports/profiler/profilerSettings/ProfilerRangeSetting.js
+++ b/imports/profiler/profilerSettings/ProfilerRangeSetting.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import TextField from 'material-ui/TextField';
+import actions from '../actions';
 
 class ProfilerRangeSetting extends Component {
   constructor(props) {
@@ -8,9 +10,114 @@ class ProfilerRangeSetting extends Component {
   }
 
   render() {
+    const { profileData } = this.props;
+    const { selectCurve } = this.props.profilerSettings;
+    const currentProfile = profileData.find((element) => {
+      return element.id.includes(selectCurve);
+    });
+    let maximum = 1;
+    let minimum = 0;
+    if (currentProfile) {
+      const { x } = currentProfile;
+      if (x) {
+        maximum = Math.max(...x);
+        minimum = Math.min(...x);
+      }
+    }
+    const { profilerSettings } = this.props;
+    // const { zoomMin, zoomMax, zoomMinPercent, zoomMaxPercent } = profilerSettings;
     return (
       <div>
-        <p>test2</p>
+        <div style={{ display: 'flex', flexDirection: 'row' }}>
+          <div style={{ flex: 1 }}>
+            <p>Minimum: </p>
+          </div>
+          <div style={{ flex: 1 }}>
+            <TextField
+              floatingLabelText="value"
+              style={{ width: '30%' }}
+              onKeyDown={(event) => {
+                const data = {};
+                data['xaxis.range[0]'] = Number(profilerSettings.zoomMin);
+                data['xaxis.range[1]'] = Number(profilerSettings.zoomMax);
+                const minPercent = 100 * ((profilerSettings.zoomMin - minimum) / (maximum - minimum));
+                const maxPercent = 100 * ((profilerSettings.zoomMax - minimum) / (maximum - minimum));
+                if (event.keyCode === 13) {
+                  this.props.dispatch(actions.onZoomPan(data));
+                  this.props.dispatch(actions.setZoomRangePercent(minPercent, maxPercent));
+                }
+              }}
+              onChange={(event, newValue) => {
+                this.props.dispatch(actions.setZoomRange(newValue, profilerSettings.zoomMax));
+              }}
+              value={profilerSettings.zoomMin}
+            />
+          </div>
+          <div style={{ flex: 1 }}>
+            <TextField
+              floatingLabelText="percentage"
+              style={{ width: '30%' }}
+              onKeyDown={(event) => {
+                const data = {};
+                data['xaxis.range[0]'] = minimum + ((maximum - minimum) * 0.01 * Number(profilerSettings.zoomMinPercent));
+                data['xaxis.range[1]'] = minimum + ((maximum - minimum) * 0.01 * Number(profilerSettings.zoomMaxPercent));
+                if (event.keyCode === 13) {
+                  this.props.dispatch(actions.onZoomPan(data));
+                  this.props.dispatch(actions.setZoomRange(data['xaxis.range[0]'], data['xaxis.range[1]']));
+                }
+              }}
+              onChange={(event, newValue) => {
+                this.props.dispatch(actions.setZoomRangePercent(newValue, profilerSettings.zoomMaxPercent));
+              }}
+              value={profilerSettings.zoomMinPercent}
+            />
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'row' }}>
+          <div style={{ flex: 1 }}>
+            <p>Maximum: </p>
+          </div>
+          <div style={{ flex: 1 }}>
+            <TextField
+              floatingLabelText="value"
+              style={{ width: '30%' }}
+              onKeyDown={(event) => {
+                const data = {};
+                data['xaxis.range[0]'] = Number(profilerSettings.zoomMin);
+                data['xaxis.range[1]'] = Number(profilerSettings.zoomMax);
+                const minPercent = 100 * ((profilerSettings.zoomMin - minimum) / (maximum - minimum));
+                const maxPercent = 100 * ((profilerSettings.zoomMax - minimum) / (maximum - minimum));
+                if (event.keyCode === 13) {
+                  this.props.dispatch(actions.onZoomPan(data));
+                  this.props.dispatch(actions.setZoomRangePercent(minPercent, maxPercent));
+                }
+              }}
+              onChange={(event, newValue) => {
+                this.props.dispatch(actions.setZoomRange(profilerSettings.zoomMin, newValue));
+              }}
+              value={profilerSettings.zoomMax}
+            />
+          </div>
+          <div style={{ flex: 1 }}>
+            <TextField
+              floatingLabelText="percentage"
+              style={{ width: '30%' }}
+              onKeyDown={(event) => {
+                const data = {};
+                data['xaxis.range[0]'] = minimum + ((maximum - minimum) * 0.01 * Number(profilerSettings.zoomMinPercent));
+                data['xaxis.range[1]'] = minimum + ((maximum - minimum) * 0.01 * Number(profilerSettings.zoomMaxPercent));
+                if (event.keyCode === 13) {
+                  this.props.dispatch(actions.onZoomPan(data));
+                  this.props.dispatch(actions.setZoomRange(data['xaxis.range[0]'], data['xaxis.range[1]']));
+                }
+              }}
+              onChange={(event, newValue) => {
+                this.props.dispatch(actions.setZoomRangePercent(profilerSettings.zoomMinPercent, newValue));
+              }}
+              value={profilerSettings.zoomMaxPercent}
+            />
+          </div>
+        </div>
       </div>
     );
   }
@@ -19,6 +126,7 @@ class ProfilerRangeSetting extends Component {
 const mapStateToProps = state => ({
   // profilerMainSetting: state.ProfilerDB.profilerMainSetting,
   profilerSettings: state.ProfilerDB.profilerSettings,
+  profileData: state.ProfilerDB.profileData,
 });
 
 export default connect(mapStateToProps)(ProfilerRangeSetting);

--- a/imports/profiler/profilerSettings/ProfilerRangeSetting.js
+++ b/imports/profiler/profilerSettings/ProfilerRangeSetting.js
@@ -12,9 +12,12 @@ class ProfilerRangeSetting extends Component {
   render() {
     const { profileData } = this.props;
     const { selectCurve } = this.props.profilerSettings;
-    const currentProfile = profileData.find((element) => {
-      return element.id.includes(selectCurve);
-    });
+    let currentProfile;
+    if (profileData) {
+      currentProfile = profileData.find((element) => {
+        return element.id.includes(selectCurve);
+      });
+    }
     let maximum = 1;
     let minimum = 0;
     if (currentProfile) {

--- a/imports/profiler/profilerSettings/ProfilerRangeSetting.js
+++ b/imports/profiler/profilerSettings/ProfilerRangeSetting.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+class ProfilerRangeSetting extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <div>
+        <p>test2</p>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  // profilerMainSetting: state.ProfilerDB.profilerMainSetting,
+  profilerSettings: state.ProfilerDB.profilerSettings,
+});
+
+export default connect(mapStateToProps)(ProfilerRangeSetting);

--- a/imports/profiler/profilerSettings/ProfilerSettings.js
+++ b/imports/profiler/profilerSettings/ProfilerSettings.js
@@ -1,0 +1,79 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import Menu from 'material-ui/Menu';
+import MenuItem from 'material-ui/MenuItem';
+import actions from '../actions';
+import ProfilerDisplaySetting from './ProfilerDisplaySetting';
+import ProfilerRangeSetting from './ProfilerRangeSetting';
+import ProfilerProfileSetting from './ProfilerProfileSetting';
+import ProfilerFitSetting from './ProfilerFitSetting';
+import ProfilerCurveSetting from './ProfilerCurveSetting';
+
+class ProfilerSettings extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    let currentProfilerSetting = null;
+    if (this.props.profilerMainSetting) {
+      switch (this.props.profilerMainSetting) {
+        case 'display':
+          currentProfilerSetting = <ProfilerDisplaySetting />;
+          break;
+        case 'range':
+          currentProfilerSetting = <ProfilerRangeSetting />;
+          break;
+        case 'profile':
+          currentProfilerSetting = <ProfilerProfileSetting />;
+          break;
+        case 'fit':
+          currentProfilerSetting = <ProfilerFitSetting />;
+          break;
+        case 'curve':
+          currentProfilerSetting = <ProfilerCurveSetting />;
+          break;
+        default:
+          break;
+      }
+    }
+    return (
+      <div style={{ flex: 1 }}>
+        <div className="rowLayout">
+          <div className="settingsUISideMenu">
+            <Menu
+              onChange={(event, value) => {
+                this.props.dispatch(actions.setProfilerMainSetting(value));
+              }}
+            >
+              <MenuItem primaryText="display" value="display" />
+              <MenuItem primaryText="range" value="range" />
+              <MenuItem primaryText="profile" value="profile" />
+              <MenuItem primaryText="fit" value="fit" />
+              <MenuItem primaryText="curve" value="curve" />
+            </Menu>
+          </div>
+          <div id="data" className="settingsUIContent">
+            {currentProfilerSetting}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // render() {
+  //   return (
+  //     <div>
+  //       <p>test</p>
+  //     </div>
+  //   );
+  // }
+}
+
+const mapStateToProps = state => ({
+  profilerMainSetting: state.ProfilerDB.profilerMainSetting,
+  // profilerSettings: state.ProfilerDB.profilerSettings,
+});
+
+export default connect(mapStateToProps)(ProfilerSettings);

--- a/imports/profiler/reducer.js
+++ b/imports/profiler/reducer.js
@@ -1,6 +1,11 @@
 import { ActionType } from './actions';
 
-const defaultState = { data: {}, zoomPanData: {} };
+const defaultState = {
+  data: {},
+  zoomPanData: {},
+  profileData: [],
+  profilerSetting: { autoGenerate: false },
+};
 const ProfilerDB = (state = defaultState, action) => {
   switch (action.type) {
     case ActionType.PROFILER_CHANGE: {

--- a/imports/profiler/reducer.js
+++ b/imports/profiler/reducer.js
@@ -1,9 +1,6 @@
 import { ActionType } from './actions';
 
 const defaultState = {
-  data: {},
-  zoomPanData: {},
-  profileData: [],
   profilerSettings: { autoGenerate: false },
 };
 const ProfilerDB = (state = defaultState, action) => {

--- a/imports/profiler/reducer.js
+++ b/imports/profiler/reducer.js
@@ -1,7 +1,7 @@
 import { ActionType } from './actions';
 
 const defaultState = {
-  profilerSettings: { autoGenerate: false },
+  profilerSettings: { },
 };
 const ProfilerDB = (state = defaultState, action) => {
   switch (action.type) {

--- a/imports/profiler/reducer.js
+++ b/imports/profiler/reducer.js
@@ -4,7 +4,7 @@ const defaultState = {
   data: {},
   zoomPanData: {},
   profileData: [],
-  profilerSetting: { autoGenerate: false },
+  profilerSettings: { autoGenerate: false },
 };
 const ProfilerDB = (state = defaultState, action) => {
   switch (action.type) {

--- a/imports/settings/Settings.js
+++ b/imports/settings/Settings.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import RaisedButton from 'material-ui/RaisedButton';
 import { Tabs, Tab } from 'material-ui/Tabs';
-import ProfilerSettings from '../app/ProfilerSettings';
+import ProfilerSettings from '../profiler/profilerSettings/ProfilerSettings';
 import HistogramSettings from '../app/HistogramSettings';
 import ImageSettings from '../imageSettings/ImageSettings';
 import StatsSettings from '../statsSettings/StatsSettings';


### PR DESCRIPTION
This PR migrates most of functions of the old CARTA, containing:
1) auto, manual generating profiles
2) enable drawing multiple profiles
3) setup the units of axes
4) select a specific profile to delete, or setup rest frequency and statistic ( not finished )
5) set up the display range
6) select profile to fit and show the fit curves
Although most of the UI elements are made, many callback functions are still not finished (Please see the comment in the Profiler/actions.js).